### PR TITLE
Aug 2018 updates - 2018-2020 regs, tool updates, bug fix

### DIFF
--- a/WildlifeTracker/MPChartLib/build.gradle
+++ b/WildlifeTracker/MPChartLib/build.gradle
@@ -3,12 +3,11 @@ apply plugin: 'maven'
 //apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    compileSdkVersion 27
     // resourcePrefix 'mpcht'
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 27
         versionCode 1
         versionName '1.0'
 
@@ -41,7 +40,8 @@ repositories {
 dependencies {
     //compile fileTree(dir: 'libs', include: ['*.jar'])
     //compile 'com.android.support:support-v4:19.+'
-    provided 'io.realm:realm-android:0.87.5' // "optional" dependency to realm-database API
+    annotationProcessor 'io.realm:realm-android:0.87.5'
+    compileOnly 'io.realm:realm-android:0.87.5' // "optional" dependency to realm-database API
 }
 
 android.libraryVariants.all { variant ->

--- a/WildlifeTracker/app/build.gradle
+++ b/WildlifeTracker/app/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "ca.bc.gov.fw.wildlifetracker"
-        minSdkVersion 10
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion 14
+        targetSdkVersion 27
+        versionCode 2
+        versionName "1.1"
     }
     buildTypes {
         release {
@@ -20,12 +19,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.android.support:appcompat-v7:${supportLibVersion}"
-    compile "com.android.support:design:${supportLibVersion}"
-    compile files('libs/otto-1.3.8.jar')
-    compile project(':MPChartLib')
-    compile 'com.android.support:support-v4:23.3.0'
-    compile 'com.google.android.gms:play-services-maps:8.4.0'
-    compile 'com.google.android.gms:play-services-location:8.4.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.android.support:appcompat-v7:${supportLibVersion}"
+    implementation "com.android.support:design:${supportLibVersion}"
+    implementation files('libs/otto-1.3.8.jar')
+    implementation project(':MPChartLib')
+    implementation "com.android.support:support-v4:${supportLibVersion}"
+    implementation "com.google.android.gms:play-services-maps:${playServicesVersion}"
+    implementation "com.google.android.gms:play-services-location:${playServicesVersion}"
 }

--- a/WildlifeTracker/app/src/main/java/ca/bc/gov/fw/wildlifetracker/RegulationsDisclaimerDialogFragment.java
+++ b/WildlifeTracker/app/src/main/java/ca/bc/gov/fw/wildlifetracker/RegulationsDisclaimerDialogFragment.java
@@ -1,0 +1,31 @@
+package ca.bc.gov.fw.wildlifetracker;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+
+public class RegulationsDisclaimerDialogFragment extends DialogFragment {
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage(R.string.regs_disclaimer_message)
+                .setTitle(R.string.regs_disclaimer_title)
+                .setPositiveButton(R.string.regs_disclaimer_ok_button, null)
+                .setNegativeButton(R.string.regs_disclaimer_view_online_button, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        Uri webpage = Uri.parse("http://www2.gov.bc.ca/gov/content/sports-culture/recreation/fishing-hunting/hunting/regulations-synopsis");
+                        Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
+                        if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
+                            startActivity(intent);
+                        }
+                    }
+                });
+        return builder.create();
+    }
+}

--- a/WildlifeTracker/app/src/main/java/ca/bc/gov/fw/wildlifetracker/RegulationsFragment.java
+++ b/WildlifeTracker/app/src/main/java/ca/bc/gov/fw/wildlifetracker/RegulationsFragment.java
@@ -1,18 +1,14 @@
 package ca.bc.gov.fw.wildlifetracker;
 
 import android.annotation.SuppressLint;
-import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -29,7 +25,7 @@ import java.util.HashMap;
 
 public class RegulationsFragment extends Fragment implements RegulationsPageFragment.RegulationsPageFragmentContainer, OnPageChangeListener, RegulationsIndexDialogFragment.RegulationsIndexDialogListener {
 
-    private static final String REGS_PDF_FILENAME = "regs_2016.pdf";
+    private static final String REGS_PDF_FILENAME = "regs_2018.pdf";
 
     public static File getRegulationsFile(Context context) throws IOException {
         File extDir = context.getExternalFilesDir(null);
@@ -37,7 +33,7 @@ public class RegulationsFragment extends Fragment implements RegulationsPageFrag
         Log.i(MainActivity.LOG_TAG, "Regs temp file: " + tempFile);
         if (!tempFile.exists()) {
             Log.i(MainActivity.LOG_TAG, "Temp file does not exist - copying from assets");
-            InputStream is = context.getAssets().open("regulations_2016_2018.pdf");
+            InputStream is = context.getAssets().open("regulations_2018_2020.pdf");
             FileOutputStream os = new FileOutputStream(tempFile);
             byte[] buffer = new byte[1024];
             int read;
@@ -157,6 +153,7 @@ public class RegulationsFragment extends Fragment implements RegulationsPageFrag
         } else if (pageToDisplay_ >= 0) {
 			showPage(pageToDisplay_);
 		}
+		setupIndexButton(getUserVisibleHint());
     }
 
 	public void showPage(int page) {
@@ -173,52 +170,7 @@ public class RegulationsFragment extends Fragment implements RegulationsPageFrag
         super.setUserVisibleHint(isVisibleToUser);
         if (getActivity() == null)
             return;
-        ImageButton indexButton = (ImageButton) getActivity().findViewById(R.id.btnRegsIndex);
-        if (indexButton != null) {
-            boolean showIndex = isVisibleToUser;
-            if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
-                // Always hide index if we're not showing regulations pages in-app
-                showIndex = false;
-            }
-            if (showIndex) {
-                indexButton.setVisibility(View.VISIBLE);
-                indexButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        RegulationsIndexDialogFragment frag = new RegulationsIndexDialogFragment();
-                        frag.setStyle(DialogFragment.STYLE_NORMAL, R.style.MyListViewStyle);
-                        frag.show(RegulationsFragment.this.getChildFragmentManager(), null);
-                    }
-                });
-            } else {
-                indexButton.setVisibility(View.GONE);
-                indexButton.setOnClickListener(null);
-            }
-        }
-        if (isVisibleToUser && !didShowDisclaimer__) {
-            didShowDisclaimer__ = true;
-            DialogFragment dialog = new DialogFragment() {
-                @NonNull
-                @Override
-                public Dialog onCreateDialog(Bundle savedInstanceState) {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                    builder.setMessage(R.string.regs_disclaimer_message)
-                            .setTitle(R.string.regs_disclaimer_title)
-                            .setPositiveButton(R.string.regs_disclaimer_ok_button, null)
-                            .setNegativeButton(R.string.regs_disclaimer_view_online_button, new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int id) {
-                                    Uri webpage = Uri.parse("http://www2.gov.bc.ca/gov/content/sports-culture/recreation/fishing-hunting/hunting/regulations-synopsis");
-                                    Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
-                                    if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
-                                        startActivity(intent);
-                                    }
-                                }
-                            });
-                    return builder.create();
-                }
-            };
-            dialog.show(getChildFragmentManager(), "DisclaimerDialogFragment");
-        }
+        setupIndexButton(isVisibleToUser);
     }
 
     @Override
@@ -253,6 +205,36 @@ public class RegulationsFragment extends Fragment implements RegulationsPageFrag
             toast_.show();
 		}
 	}
+
+	private void setupIndexButton(boolean visible) {
+        ImageButton indexButton = (ImageButton) getActivity().findViewById(R.id.btnRegsIndex);
+        if (indexButton != null) {
+            boolean showIndex = visible;
+            if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
+                // Always hide index if we're not showing regulations pages in-app
+                showIndex = false;
+            }
+            if (showIndex) {
+                indexButton.setVisibility(View.VISIBLE);
+                indexButton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        RegulationsIndexDialogFragment frag = new RegulationsIndexDialogFragment();
+                        frag.setStyle(DialogFragment.STYLE_NORMAL, R.style.MyListViewStyle);
+                        frag.show(RegulationsFragment.this.getChildFragmentManager(), null);
+                    }
+                });
+            } else {
+                indexButton.setVisibility(View.GONE);
+                indexButton.setOnClickListener(null);
+            }
+        }
+        if (visible && !didShowDisclaimer__) {
+            didShowDisclaimer__ = true;
+            DialogFragment dialog = new RegulationsDisclaimerDialogFragment();
+            dialog.show(getChildFragmentManager(), "RegulationsDisclaimerDialogFragment");
+        }
+    }
 
 	@Override
 	public void onPageScrollStateChanged(int arg0) {		

--- a/WildlifeTracker/app/src/main/java/ca/bc/gov/fw/wildlifetracker/SightingsFragment.java
+++ b/WildlifeTracker/app/src/main/java/ca/bc/gov/fw/wildlifetracker/SightingsFragment.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.fw.wildlifetracker;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.IntentSender;
 import android.content.SharedPreferences;
@@ -368,12 +369,13 @@ public class SightingsFragment extends Fragment
             return;
         }
         RegionManager.RegionResult result = RegionManager.getInstance().regionsForLocation(location);
-        if ((result.regions_ != null) && (result.regions_.length > 0) && !userHasChangedMU_) {
+        if ((result != null) && (result.regions_ != null) && (result.regions_.length > 0) && !userHasChangedMU_) {
             Log.d(MainActivity.LOG_TAG, "Setting region from location: " + result.regions_[0].name_);
             regionPicked(result.regions_[0].name_);
         }
     }
 
+    @SuppressLint("MissingPermission")
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode != LOCATIONS_PERMISSION_REQUEST_CODE) {

--- a/WildlifeTracker/build.gradle
+++ b/WildlifeTracker/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -13,11 +14,13 @@ buildscript {
 }
 
 ext {
-    supportLibVersion = '23.2.1'
+    supportLibVersion = '27.1.1'
+    playServicesVersion = '15.0.1'
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/WildlifeTracker/gradle/wrapper/gradle-wrapper.properties
+++ b/WildlifeTracker/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This update includes the latest (2018-08-14) regulations PDF, and a number of configuration and code changes to support the latest tools (Android Studio 3.1.4) and build with the current Android SDK (27, Oreo).

Testing revealed a bug in which the disclaimer dialog and index button were not correctly shown the first time the Regulations tab was displayed, so a fix for that is included.

.gitignore file doesn't seem to correctly exclude some files in the .idea folder(s). Changes to those files (and .gitignore itself) were not committed as part of this update.

Reference to BCDevExchange opportunity as per 
https://github.com/bcgov/env-moosetracker-ios/issues/1